### PR TITLE
Add Java 17 to 21 Spring Boot baseline rule

### DIFF
--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/DefaultMigrationRules.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/DefaultMigrationRules.java
@@ -14,6 +14,7 @@ public final class DefaultMigrationRules {
         return List.of(
                 DefaultMigrationRules::java8Baseline,
                 DefaultMigrationRules::springBoot2Compatibility,
+                DefaultMigrationRules::springBootJava17To21BaselineReview,
                 DefaultMigrationRules::explicitMavenCompilerPlugin,
                 DefaultMigrationRules::openRewriteMigrationRecipe,
                 DefaultMigrationRules::sourcePatternFindings);
@@ -54,6 +55,28 @@ public final class DefaultMigrationRules {
                 "Validate the project on Spring Boot 2.7.x before the Java "
                         + context.request().targetJavaVersion()
                         + " rollout. Treat Spring Boot 3 as a separate migration because it also introduces Jakarta namespace changes.",
+                null));
+    }
+
+    private static List<Finding> springBootJava17To21BaselineReview(RuleContext context) {
+        var springBootVersion = context.metadata().springBootVersion();
+        if (context.request().targetJavaVersion() != 21
+                || !declaresJava17(context.metadata())
+                || springBootVersion == null
+                || springBootVersion.startsWith("2.")) {
+            return List.of();
+        }
+
+        return List.of(new Finding(
+                "spring-boot-java-17-to-21-baseline-review",
+                FindingCategory.FRAMEWORK,
+                FindingSeverity.INFO,
+                "Spring Boot compatibility",
+                "Spring Boot baseline should be reviewed before a Java 21 rollout",
+                "Declared Java version is " + context.metadata().declaredJavaVersion()
+                        + "; detected Spring Boot " + springBootVersion
+                        + "; target Java version is " + context.request().targetJavaVersion(),
+                "Validate the selected Spring Boot line against Java 21 before runtime rollout. Treat framework upgrades, dependency baselines, and CI runtime changes as explicit migration work rather than language modernization.",
                 null));
     }
 
@@ -175,5 +198,9 @@ public final class DefaultMigrationRules {
 
     private static boolean declaresJava8(ProjectMetadata metadata) {
         return "8".equals(metadata.declaredJavaVersion()) || "1.8".equals(metadata.declaredJavaVersion());
+    }
+
+    private static boolean declaresJava17(ProjectMetadata metadata) {
+        return "17".equals(metadata.declaredJavaVersion());
     }
 }

--- a/analyzer-core/src/test/java/dev/modernjava/upgrade/core/DefaultAnalyzerTest.java
+++ b/analyzer-core/src/test/java/dev/modernjava/upgrade/core/DefaultAnalyzerTest.java
@@ -76,6 +76,51 @@ class DefaultAnalyzerTest {
     }
 
     @Test
+    void reportsSpringBootBaselineReviewForJava17To21Migration() {
+        var metadata = new ProjectMetadata(
+                "maven",
+                "17",
+                "3.1.12",
+                List.of("org.springframework.boot:spring-boot-starter-web"),
+                List.of("org.apache.maven.plugins:maven-compiler-plugin"));
+        var request = new AnalysisRequest(Path.of("."), 21);
+
+        var result = new DefaultAnalyzer(metadata).analyze(request);
+
+        assertThat(result.findings())
+                .extracting(Finding::id)
+                .contains("spring-boot-java-17-to-21-baseline-review");
+        assertThat(result.findings())
+                .filteredOn(finding -> finding.id().equals("spring-boot-java-17-to-21-baseline-review"))
+                .singleElement()
+                .satisfies(finding -> {
+                    assertThat(finding.category()).isEqualTo(FindingCategory.FRAMEWORK);
+                    assertThat(finding.severity()).isEqualTo(FindingSeverity.INFO);
+                    assertThat(finding.evidence()).isEqualTo("Declared Java version is 17; detected Spring Boot 3.1.12; target Java version is 21");
+                    assertThat(finding.recommendation())
+                            .contains("Validate the selected Spring Boot line against Java 21")
+                            .contains("before runtime rollout");
+                });
+    }
+
+    @Test
+    void doesNotReportSpringBootBaselineReviewOutsideJava17To21Migration() {
+        var metadata = new ProjectMetadata(
+                "maven",
+                "17",
+                "3.1.12",
+                List.of("org.springframework.boot:spring-boot-starter-web"),
+                List.of("org.apache.maven.plugins:maven-compiler-plugin"));
+        var request = new AnalysisRequest(Path.of("."), 17);
+
+        var result = new DefaultAnalyzer(metadata).analyze(request);
+
+        assertThat(result.findings())
+                .extracting(Finding::id)
+                .doesNotContain("spring-boot-java-17-to-21-baseline-review");
+    }
+
+    @Test
     void reportsSourceModernizationFindings() {
         var metadata = new ProjectMetadata(
                 "maven",

--- a/docs/engineering-log/000-index.md
+++ b/docs/engineering-log/000-index.md
@@ -18,6 +18,7 @@ The goal is not to maintain a generic changelog. Each entry captures technical d
 - [010 - CLI MVP closure](010-cli-mvp-closure.md)
 - [011 - English technical documentation baseline](011-english-technical-documentation.md)
 - [012 - Public repository readiness](012-public-repository-readiness.md)
+- [013 - Java 17 to 21 Spring Boot baseline rule](013-java-17-to-21-spring-boot-baseline-rule.md)
 
 ## Entry Format
 

--- a/docs/engineering-log/013-java-17-to-21-spring-boot-baseline-rule.md
+++ b/docs/engineering-log/013-java-17-to-21-spring-boot-baseline-rule.md
@@ -1,0 +1,61 @@
+# 013 - Java 17 to 21 Spring Boot Baseline Rule
+
+## Date
+
+2026-04-22
+
+## Goal
+
+Implement issue #1: add a focused Java 17 -> Java 21 migration rule that reminds teams to validate their Spring Boot baseline before runtime rollout.
+
+## Decisions
+
+- Add the rule in `analyzer-core`, where migration knowledge currently lives.
+- Trigger the rule only when the project declares Java 17, targets Java 21, and has a detected Spring Boot version.
+- Do not duplicate the existing Spring Boot 2.x risk rule. Spring Boot 2.x keeps the stronger existing compatibility warning.
+- Use `INFO` severity because this rule is an advisory review gate, not proof of incompatibility.
+
+## Rejected Options
+
+- Do not encode a full Spring Boot support matrix in this first issue. That would require broader framework-version policy and maintenance.
+- Do not make the rule target every Java 21 migration. The issue is specifically about Java 17 -> 21 projects.
+- Do not imply that the analyzer fully verifies runtime compatibility.
+
+## Rationale
+
+The rule improves the migration report by making framework baseline review explicit. For senior engineers, the useful output is not "Java 21 is available"; it is "before the runtime rollout, validate the framework line, dependency baselines, and CI runtime assumptions."
+
+## Implementation Notes
+
+I followed TDD:
+
+1. Added a failing analyzer test expecting `spring-boot-java-17-to-21-baseline-review`.
+2. Verified RED: the report only contained `openrewrite-java-21`.
+3. Added `springBootJava17To21BaselineReview` to `DefaultMigrationRules`.
+4. Verified GREEN in `analyzer-core`.
+
+## Verification
+
+Module verification:
+
+```powershell
+mvn -pl analyzer-core test
+```
+
+Result: 15 analyzer-core tests passed.
+
+Full reactor verification:
+
+```powershell
+mvn test
+```
+
+Result: 32 tests passed across the reactor. Maven still emits the known JDK 25 `sun.misc.Unsafe` warning from Maven/Guice, but the build succeeds.
+
+## Content Angle
+
+This rule is a small but useful example for contributors: a migration rule should be scoped, evidence-backed, advisory when appropriate, and explicit about what it does not prove.
+
+## Next Step
+
+Run the full test suite, push the branch, open a pull request, and close issue #1 through the PR.


### PR DESCRIPTION
## Summary

- Add an advisory Java 17 -> Java 21 Spring Boot baseline review rule.
- Keep Spring Boot 2.x on the existing stronger compatibility risk rule to avoid duplicate findings.
- Add analyzer tests for positive and negative target-version behavior.
- Document the decision in the engineering log.

Closes #1

## Verification

- mvn -pl analyzer-core test -> 15 tests passed
- mvn test -> 32 tests passed