### PR TITLE
Add Java 21 to 25 baseline review rule

### DIFF
--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/DefaultMigrationRules.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/DefaultMigrationRules.java
@@ -13,6 +13,7 @@ public final class DefaultMigrationRules {
     public static List<MigrationRule> defaults() {
         return List.of(
                 DefaultMigrationRules::java8Baseline,
+                DefaultMigrationRules::java21To25BaselineReview,
                 DefaultMigrationRules::springBoot2Compatibility,
                 DefaultMigrationRules::springBootJava17To21BaselineReview,
                 DefaultMigrationRules::explicitMavenCompilerPlugin,
@@ -35,6 +36,23 @@ public final class DefaultMigrationRules {
                 "Declared Java version is " + context.metadata().declaredJavaVersion(),
                 "Establish a Java " + context.request().targetJavaVersion()
                         + " build and test baseline before introducing optional language modernization.",
+                null));
+    }
+
+    private static List<Finding> java21To25BaselineReview(RuleContext context) {
+        if (context.request().targetJavaVersion() != 25 || !declaresJava21(context.metadata())) {
+            return List.of();
+        }
+
+        return List.of(new Finding(
+                "java-21-to-25-baseline-review",
+                FindingCategory.BASELINE,
+                FindingSeverity.INFO,
+                "Java baseline",
+                "Java 21 to 25 migration should start with a build and test baseline",
+                "Declared Java version is " + context.metadata().declaredJavaVersion()
+                        + "; target Java version is " + context.request().targetJavaVersion(),
+                "Establish a Java 25 build and test baseline before enabling optional language, runtime, GC, JFR, or AOT changes.",
                 null));
     }
 
@@ -202,5 +220,9 @@ public final class DefaultMigrationRules {
 
     private static boolean declaresJava17(ProjectMetadata metadata) {
         return "17".equals(metadata.declaredJavaVersion());
+    }
+
+    private static boolean declaresJava21(ProjectMetadata metadata) {
+        return "21".equals(metadata.declaredJavaVersion());
     }
 }

--- a/analyzer-core/src/test/java/dev/modernjava/upgrade/core/DefaultAnalyzerTest.java
+++ b/analyzer-core/src/test/java/dev/modernjava/upgrade/core/DefaultAnalyzerTest.java
@@ -121,6 +121,51 @@ class DefaultAnalyzerTest {
     }
 
     @Test
+    void reportsJava21To25BaselineReview() {
+        var metadata = new ProjectMetadata(
+                "gradle",
+                "21",
+                "3.4.4",
+                List.of("org.springframework.boot:spring-boot-starter-web"),
+                List.of("org.springframework.boot"));
+        var request = new AnalysisRequest(Path.of("."), 25);
+
+        var result = new DefaultAnalyzer(metadata).analyze(request);
+
+        assertThat(result.findings())
+                .filteredOn(finding -> finding.id().equals("java-21-to-25-baseline-review"))
+                .singleElement()
+                .satisfies(finding -> {
+                    assertThat(finding.category()).isEqualTo(FindingCategory.BASELINE);
+                    assertThat(finding.severity()).isEqualTo(FindingSeverity.INFO);
+                    assertThat(finding.evidence()).isEqualTo("Declared Java version is 21; target Java version is 25");
+                    assertThat(finding.recommendation())
+                            .contains("Establish a Java 25 build and test baseline")
+                            .contains("language")
+                            .contains("runtime")
+                            .contains("GC")
+                            .contains("JFR")
+                            .contains("AOT");
+                });
+    }
+
+    @Test
+    void doesNotReportJava21To25BaselineReviewForOtherTransitions() {
+        var java17Metadata = new ProjectMetadata("maven", "17", "3.1.12", List.of(), List.of());
+        var java21Metadata = new ProjectMetadata("maven", "21", "3.4.4", List.of(), List.of());
+
+        var java17To25 = new DefaultAnalyzer(java17Metadata).analyze(new AnalysisRequest(Path.of("."), 25));
+        var java21To21 = new DefaultAnalyzer(java21Metadata).analyze(new AnalysisRequest(Path.of("."), 21));
+
+        assertThat(java17To25.findings())
+                .extracting(Finding::id)
+                .doesNotContain("java-21-to-25-baseline-review");
+        assertThat(java21To21.findings())
+                .extracting(Finding::id)
+                .doesNotContain("java-21-to-25-baseline-review");
+    }
+
+    @Test
     void reportsSourceModernizationFindings() {
         var metadata = new ProjectMetadata(
                 "maven",

--- a/docs/engineering-log/000-index.md
+++ b/docs/engineering-log/000-index.md
@@ -20,6 +20,7 @@ The goal is not to maintain a generic changelog. Each entry captures technical d
 - [012 - Public repository readiness](012-public-repository-readiness.md)
 - [013 - Java 17 to 21 Spring Boot baseline rule](013-java-17-to-21-spring-boot-baseline-rule.md)
 - [014 - Java 21 to 25 rule catalog](014-java-21-to-25-rule-catalog.md)
+- [015 - Java 21 to 25 baseline review rule](015-java-21-to-25-baseline-review-rule.md)
 
 ## Entry Format
 

--- a/docs/engineering-log/015-java-21-to-25-baseline-review-rule.md
+++ b/docs/engineering-log/015-java-21-to-25-baseline-review-rule.md
@@ -1,0 +1,64 @@
+# 015 - Java 21 to 25 Baseline Review Rule
+
+## Date
+
+2026-04-22
+
+## Goal
+
+Implement the first rule from the Java 21 -> Java 25 catalog: `java-21-to-25-baseline-review`.
+
+## Decisions
+
+- Add the rule to `DefaultMigrationRules`.
+- Trigger only when the project declares Java 21 and the requested target is Java 25.
+- Keep the rule `BASELINE` / `INFO`.
+- Make the recommendation about establishing build and test confidence before optional Java 25 work.
+
+## Rejected Options
+
+- Do not recommend specific Java 25 features from this rule.
+- Do not fire for Java 17 -> 25. That transition needs separate baseline logic because it includes both Java 21 and Java 25 adoption work.
+- Do not make this a framework compatibility rule. The observable evidence is the Java baseline transition.
+
+## Rationale
+
+This is the lowest-risk implementation from the Java 21 -> 25 catalog. It gives Java 25 reports immediate value while keeping the project aligned with evidence-based migration guidance.
+
+The recommendation deliberately mentions language, runtime, GC, JFR, and AOT as optional areas that should come after the baseline is green.
+
+## Implementation Notes
+
+I followed TDD:
+
+1. Added a failing analyzer test expecting `java-21-to-25-baseline-review`.
+2. Verified RED: no finding with that id was produced.
+3. Added `java21To25BaselineReview` to `DefaultMigrationRules`.
+4. Added negative coverage for Java 17 -> 25 and Java 21 -> 21.
+5. Verified GREEN in `analyzer-core` and the full reactor.
+
+## Verification
+
+Module verification:
+
+```powershell
+mvn -pl analyzer-core test
+```
+
+Result: 17 analyzer-core tests passed.
+
+Full reactor verification:
+
+```powershell
+mvn test
+```
+
+Result: 34 tests passed. Maven still emits the known JDK 25 `sun.misc.Unsafe` warning from Maven/Guice, but the build succeeds.
+
+## Content Angle
+
+This is a practical example of turning a rule catalog into analyzer behavior without expanding scope. The first Java 25 rule is not about new syntax; it is about creating a stable migration baseline.
+
+## Next Step
+
+Open a PR that closes the implementation issue, then move to the next catalog item: `threadlocal-to-scoped-values-review`.


### PR DESCRIPTION
## Summary

- Add java-21-to-25-baseline-review as the first implemented Java 21 -> 25 catalog rule.
- Keep the finding BASELINE / INFO and evidence-backed from declared Java version plus target version.
- Add positive and negative analyzer tests.
- Document the implementation in the engineering log.

Closes #8

## Verification

- mvn -pl analyzer-core test -> 17 tests passed
- mvn test -> 34 tests passed