### PR TITLE
Add ThreadLocal scoped values review

### DIFF
--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/DefaultMigrationRules.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/DefaultMigrationRules.java
@@ -147,6 +147,7 @@ public final class DefaultMigrationRules {
                     case MAP_STRING_OBJECT -> mapStringObjectFinding(pattern);
                     case SIMPLE_DATE_FORMAT -> simpleDateFormatFinding(pattern);
                     case EXECUTOR_FACTORY -> executorFactoryFinding(pattern);
+                    case THREAD_LOCAL -> threadLocalFinding(pattern);
                 })
                 .toList();
     }
@@ -155,6 +156,7 @@ public final class DefaultMigrationRules {
         return switch (pattern.type()) {
             case MAP_STRING_OBJECT, SIMPLE_DATE_FORMAT -> targetsJava17OrLater(context);
             case EXECUTOR_FACTORY -> context.request().targetJavaVersion() >= 21;
+            case THREAD_LOCAL -> declaresJava21(context.metadata()) && context.request().targetJavaVersion() == 25;
         };
     }
 
@@ -191,6 +193,18 @@ public final class DefaultMigrationRules {
                 "Executor factory usage should be reviewed before adopting virtual threads",
                 sourceEvidence(pattern),
                 "Evaluate whether this blocking workload can use virtual threads after measuring behavior and preserving executor lifecycle boundaries.",
+                null);
+    }
+
+    private static Finding threadLocalFinding(SourcePattern pattern) {
+        return new Finding(
+                sourceFindingId(pattern),
+                FindingCategory.CONCURRENCY,
+                FindingSeverity.INFO,
+                "Concurrency modernization",
+                "ThreadLocal usage should be reviewed for scoped values",
+                sourceEvidence(pattern),
+                "Review whether this context propagation can move toward scoped values on Java 25. Do not rewrite automatically; validate lifecycle, framework integration, and request boundaries first.",
                 null);
     }
 

--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/SourcePatternScanner.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/SourcePatternScanner.java
@@ -68,6 +68,13 @@ public final class SourcePatternScanner {
                         index + 1,
                         lines.get(index)));
             }
+            if (line.contains("ThreadLocal") && reportedTypes.add(SourcePatternType.THREAD_LOCAL)) {
+                patterns.add(new SourcePattern(
+                        SourcePatternType.THREAD_LOCAL,
+                        relativePath,
+                        index + 1,
+                        lines.get(index)));
+            }
         }
     }
 

--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/SourcePatternType.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/SourcePatternType.java
@@ -3,5 +3,6 @@ package dev.modernjava.upgrade.core;
 public enum SourcePatternType {
     MAP_STRING_OBJECT,
     SIMPLE_DATE_FORMAT,
-    EXECUTOR_FACTORY
+    EXECUTOR_FACTORY,
+    THREAD_LOCAL
 }

--- a/analyzer-core/src/test/java/dev/modernjava/upgrade/core/DefaultAnalyzerTest.java
+++ b/analyzer-core/src/test/java/dev/modernjava/upgrade/core/DefaultAnalyzerTest.java
@@ -166,6 +166,57 @@ class DefaultAnalyzerTest {
     }
 
     @Test
+    void reportsThreadLocalAsScopedValuesReviewForJava21To25Migration() {
+        var metadata = new ProjectMetadata(
+                "maven",
+                "21",
+                "3.4.4",
+                List.of(),
+                List.of(),
+                List.of(new SourcePattern(
+                        SourcePatternType.THREAD_LOCAL,
+                        Path.of("src/main/java/example/RequestContext.java"),
+                        6,
+                        "private static final ThreadLocal<String> TENANT = new ThreadLocal<>();")));
+        var request = new AnalysisRequest(Path.of("."), 25);
+
+        var result = new DefaultAnalyzer(metadata).analyze(request);
+
+        assertThat(result.findings())
+                .filteredOn(finding -> finding.id().equals("source-thread-local-src-main-java-example-requestcontext-java-6"))
+                .singleElement()
+                .satisfies(finding -> {
+                    assertThat(finding.category()).isEqualTo(FindingCategory.CONCURRENCY);
+                    assertThat(finding.severity()).isEqualTo(FindingSeverity.INFO);
+                    assertThat(finding.title()).isEqualTo("ThreadLocal usage should be reviewed for scoped values");
+                    assertThat(finding.recommendation())
+                            .contains("scoped values on Java 25")
+                            .contains("Do not rewrite automatically");
+                });
+    }
+
+    @Test
+    void doesNotReportThreadLocalAsScopedValuesReviewOutsideJava21To25Migration() {
+        var sourcePatterns = List.of(new SourcePattern(
+                SourcePatternType.THREAD_LOCAL,
+                Path.of("src/main/java/example/RequestContext.java"),
+                6,
+                "private static final ThreadLocal<String> TENANT = new ThreadLocal<>();"));
+        var java17Metadata = new ProjectMetadata("maven", "17", "3.1.12", List.of(), List.of(), sourcePatterns);
+        var java21Metadata = new ProjectMetadata("maven", "21", "3.4.4", List.of(), List.of(), sourcePatterns);
+
+        var java17To25 = new DefaultAnalyzer(java17Metadata).analyze(new AnalysisRequest(Path.of("."), 25));
+        var java21To21 = new DefaultAnalyzer(java21Metadata).analyze(new AnalysisRequest(Path.of("."), 21));
+
+        assertThat(java17To25.findings())
+                .extracting(Finding::id)
+                .doesNotContain("source-thread-local-src-main-java-example-requestcontext-java-6");
+        assertThat(java21To21.findings())
+                .extracting(Finding::id)
+                .doesNotContain("source-thread-local-src-main-java-example-requestcontext-java-6");
+    }
+
+    @Test
     void reportsSourceModernizationFindings() {
         var metadata = new ProjectMetadata(
                 "maven",

--- a/analyzer-core/src/test/java/dev/modernjava/upgrade/core/SourcePatternScannerTest.java
+++ b/analyzer-core/src/test/java/dev/modernjava/upgrade/core/SourcePatternScannerTest.java
@@ -87,4 +87,28 @@ class SourcePatternScannerTest {
                 .extracting(SourcePattern::lineNumber)
                 .containsExactly(6);
     }
+
+    @Test
+    void detectsThreadLocalUsageOutsideImports() throws Exception {
+        var source = tempDir.resolve("src/main/java/example/RequestContext.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, """
+                package example;
+
+                import java.lang.ThreadLocal;
+
+                final class RequestContext {
+                    private static final ThreadLocal<String> TENANT = new ThreadLocal<>();
+                }
+                """);
+
+        var patterns = new SourcePatternScanner().scan(tempDir);
+
+        assertThat(patterns)
+                .extracting(SourcePattern::type)
+                .containsExactly(SourcePatternType.THREAD_LOCAL);
+        assertThat(patterns)
+                .extracting(SourcePattern::lineNumber)
+                .containsExactly(6);
+    }
 }

--- a/docs/engineering-log/000-index.md
+++ b/docs/engineering-log/000-index.md
@@ -21,6 +21,7 @@ The goal is not to maintain a generic changelog. Each entry captures technical d
 - [013 - Java 17 to 21 Spring Boot baseline rule](013-java-17-to-21-spring-boot-baseline-rule.md)
 - [014 - Java 21 to 25 rule catalog](014-java-21-to-25-rule-catalog.md)
 - [015 - Java 21 to 25 baseline review rule](015-java-21-to-25-baseline-review-rule.md)
+- [016 - ThreadLocal scoped values review rule](016-threadlocal-scoped-values-review-rule.md)
 
 ## Entry Format
 

--- a/docs/engineering-log/016-threadlocal-scoped-values-review-rule.md
+++ b/docs/engineering-log/016-threadlocal-scoped-values-review-rule.md
@@ -1,0 +1,72 @@
+# 016 - ThreadLocal Scoped Values Review Rule
+
+## Date
+
+2026-04-22
+
+## Goal
+
+Implement the second Java 21 -> Java 25 catalog item: detect direct `ThreadLocal` usage and report it as a scoped-values review candidate.
+
+## Decisions
+
+- Extend the existing textual source scanner with a `THREAD_LOCAL` pattern.
+- Ignore imports as the scanner already does for other patterns.
+- Generate a `CONCURRENCY` / `INFO` finding only for Java 21 -> Java 25 migrations.
+- Keep the recommendation advisory and explicitly avoid automatic rewriting.
+
+## Rejected Options
+
+- Do not introduce JavaParser yet. Direct `ThreadLocal` usage is detectable with the current scanner and gives enough signal for an advisory finding.
+- Do not include structured concurrency in this rule. Structured concurrency remains preview in Java 25 and needs a separate preview-boundary rule.
+- Do not recommend replacing every `ThreadLocal`; framework integration and lifecycle boundaries matter.
+
+## Rationale
+
+Scoped values are final in Java 25 and are relevant to context propagation. However, `ThreadLocal` usage can be intentional, framework-managed, or safe in a given lifecycle.
+
+The report should therefore surface the evidence and ask for review. It should not imply that scoped values are a universal replacement.
+
+## Implementation Notes
+
+I followed TDD:
+
+1. Added a scanner test expecting `SourcePatternType.THREAD_LOCAL`.
+2. Verified RED: the enum value did not exist.
+3. Added the enum value and textual scanner detection.
+4. Updated exhaustive switches in `DefaultMigrationRules`.
+5. Added analyzer tests for Java 21 -> 25 positive behavior and negative behavior for Java 17 -> 25 and Java 21 -> 21.
+
+## Verification
+
+Scanner verification:
+
+```powershell
+mvn -pl analyzer-core -Dtest=SourcePatternScannerTest test
+```
+
+Result: 4 scanner tests passed.
+
+Module verification:
+
+```powershell
+mvn -pl analyzer-core test
+```
+
+Result: 20 analyzer-core tests passed.
+
+Full reactor verification:
+
+```powershell
+mvn test
+```
+
+Result: 37 tests passed. Maven still emits the known JDK 25 `sun.misc.Unsafe` warning from Maven/Guice, but the build succeeds.
+
+## Content Angle
+
+This rule is a useful example of conservative modernization guidance. The analyzer detects `ThreadLocal` evidence, but the recommendation stays explicit about human review and framework context.
+
+## Next Step
+
+Open a PR that closes the implementation issue. After merge, decide whether the next Java 25 rule should be preview-feature boundary detection or direct `sun.misc.Unsafe` source detection.


### PR DESCRIPTION
## Summary

- Add THREAD_LOCAL source pattern detection to the textual scanner.
- Report direct ThreadLocal usage as a Java 21 -> 25 scoped-values review candidate.
- Keep the finding advisory: CONCURRENCY / INFO, no automatic rewrite recommendation.
- Add scanner and analyzer coverage for positive and negative transitions.
- Document the implementation in the engineering log.

Closes #10

## Verification

- mvn -pl analyzer-core -Dtest=SourcePatternScannerTest test -> 4 tests passed
- mvn -pl analyzer-core test -> 20 tests passed
- mvn test -> 37 tests passed