### PR TITLE
Add Java 25 boundary rule evidence

### DIFF
--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/DefaultMigrationRules.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/DefaultMigrationRules.java
@@ -17,6 +17,7 @@ public final class DefaultMigrationRules {
                 DefaultMigrationRules::springBoot2Compatibility,
                 DefaultMigrationRules::springBootJava17To21BaselineReview,
                 DefaultMigrationRules::explicitMavenCompilerPlugin,
+                DefaultMigrationRules::java25PreviewFeatureBoundary,
                 DefaultMigrationRules::openRewriteMigrationRecipe,
                 DefaultMigrationRules::sourcePatternFindings);
     }
@@ -118,6 +119,32 @@ public final class DefaultMigrationRules {
                 null));
     }
 
+    private static List<Finding> java25PreviewFeatureBoundary(RuleContext context) {
+        if (context.request().targetJavaVersion() != 25 || !declaresJava21(context.metadata())) {
+            return List.of();
+        }
+
+        var previewArg = context.metadata().compilerArgs().stream()
+                .filter("--enable-preview"::equals)
+                .findFirst()
+                .orElse(null);
+        if (previewArg == null) {
+            return List.of();
+        }
+
+        return List.of(new Finding(
+                "jdk-25-preview-feature-boundary",
+                FindingCategory.BUILD,
+                FindingSeverity.RISK,
+                "Compiler flags",
+                "Preview feature usage is a Java 25 migration boundary",
+                "Declared Java version is " + context.metadata().declaredJavaVersion()
+                        + "; target Java version is " + context.request().targetJavaVersion()
+                        + "; detected compiler argument `" + previewArg + "`",
+                "Treat preview/incubator feature usage as explicit technical debt. Verify source/bytecode compatibility on every JDK update.",
+                null));
+    }
+
     private static List<Finding> openRewriteMigrationRecipe(RuleContext context) {
         var recipe = switch (context.request().targetJavaVersion()) {
             case 17 -> "org.openrewrite.java.migrate.UpgradeToJava17";
@@ -148,6 +175,7 @@ public final class DefaultMigrationRules {
                     case SIMPLE_DATE_FORMAT -> simpleDateFormatFinding(pattern);
                     case EXECUTOR_FACTORY -> executorFactoryFinding(pattern);
                     case THREAD_LOCAL -> threadLocalFinding(pattern);
+                    case UNSAFE_MEMORY_ACCESS -> unsafeMemoryAccessFinding(pattern);
                 })
                 .toList();
     }
@@ -157,6 +185,7 @@ public final class DefaultMigrationRules {
             case MAP_STRING_OBJECT, SIMPLE_DATE_FORMAT -> targetsJava17OrLater(context);
             case EXECUTOR_FACTORY -> context.request().targetJavaVersion() >= 21;
             case THREAD_LOCAL -> declaresJava21(context.metadata()) && context.request().targetJavaVersion() == 25;
+            case UNSAFE_MEMORY_ACCESS -> declaresJava21(context.metadata()) && context.request().targetJavaVersion() == 25;
         };
     }
 
@@ -205,6 +234,18 @@ public final class DefaultMigrationRules {
                 "ThreadLocal usage should be reviewed for scoped values",
                 sourceEvidence(pattern),
                 "Review whether this context propagation can move toward scoped values on Java 25. Do not rewrite automatically; validate lifecycle, framework integration, and request boundaries first.",
+                null);
+    }
+
+    private static Finding unsafeMemoryAccessFinding(SourcePattern pattern) {
+        return new Finding(
+                sourceFindingId(pattern),
+                FindingCategory.BUILD,
+                FindingSeverity.RISK,
+                "Unsafe memory access",
+                "Direct sun.misc.Unsafe usage should be removed or isolated",
+                sourceEvidence(pattern),
+                "Remove direct unsafe memory-access usage where possible and audit dependencies that emit JDK warnings.",
                 null);
     }
 

--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/ProjectMetadata.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/ProjectMetadata.java
@@ -9,6 +9,7 @@ public record ProjectMetadata(
         String springBootVersion,
         List<String> dependencies,
         List<String> buildPlugins,
+        List<String> compilerArgs,
         List<SourcePattern> sourcePatterns) {
 
     public ProjectMetadata {
@@ -17,17 +18,23 @@ public record ProjectMetadata(
         springBootVersion = normalizeOptionalText(springBootVersion);
         dependencies = List.copyOf(Objects.requireNonNull(dependencies, "dependencies"));
         buildPlugins = List.copyOf(Objects.requireNonNull(buildPlugins, "buildPlugins"));
+        compilerArgs = List.copyOf(Objects.requireNonNull(compilerArgs, "compilerArgs"));
         sourcePatterns = List.copyOf(Objects.requireNonNull(sourcePatterns, "sourcePatterns"));
     }
 
     public ProjectMetadata(String buildTool, String declaredJavaVersion, String springBootVersion,
             List<String> dependencies, List<String> buildPlugins) {
-        this(buildTool, declaredJavaVersion, springBootVersion, dependencies, buildPlugins, List.of());
+        this(buildTool, declaredJavaVersion, springBootVersion, dependencies, buildPlugins, List.of(), List.of());
+    }
+
+    public ProjectMetadata(String buildTool, String declaredJavaVersion, String springBootVersion,
+            List<String> dependencies, List<String> buildPlugins, List<SourcePattern> sourcePatterns) {
+        this(buildTool, declaredJavaVersion, springBootVersion, dependencies, buildPlugins, List.of(), sourcePatterns);
     }
 
     public ProjectMetadata(String buildTool, String declaredJavaVersion, String springBootVersion,
             List<String> dependencies) {
-        this(buildTool, declaredJavaVersion, springBootVersion, dependencies, List.of(), List.of());
+        this(buildTool, declaredJavaVersion, springBootVersion, dependencies, List.of(), List.of(), List.of());
     }
 
     private static String normalizeOptionalText(String value) {

--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/SourcePatternScanner.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/SourcePatternScanner.java
@@ -10,8 +10,11 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 public final class SourcePatternScanner {
+
+    private static final Pattern UNSAFE_SIMPLE_NAME = Pattern.compile("\\bUnsafe\\b");
 
     public List<SourcePattern> scan(Path projectPath) {
         Objects.requireNonNull(projectPath, "projectPath");
@@ -39,10 +42,12 @@ public final class SourcePatternScanner {
 
     private static void scanFile(Path root, Path javaFile, List<SourcePattern> patterns) throws IOException {
         var lines = Files.readAllLines(javaFile, StandardCharsets.UTF_8);
+        var sanitizedLines = stripCommentsAndLiterals(lines);
         var relativePath = root.relativize(javaFile);
         var reportedTypes = EnumSet.noneOf(SourcePatternType.class);
+        var importsUnsafe = importsSunMiscUnsafe(sanitizedLines);
         for (int index = 0; index < lines.size(); index++) {
-            var line = stripLineComment(lines.get(index));
+            var line = sanitizedLines.get(index);
             if (line.stripLeading().startsWith("import ")) {
                 continue;
             }
@@ -75,6 +80,13 @@ public final class SourcePatternScanner {
                         index + 1,
                         lines.get(index)));
             }
+            if (isUnsafeUsage(line, importsUnsafe) && reportedTypes.add(SourcePatternType.UNSAFE_MEMORY_ACCESS)) {
+                patterns.add(new SourcePattern(
+                        SourcePatternType.UNSAFE_MEMORY_ACCESS,
+                        relativePath,
+                        index + 1,
+                        lines.get(index)));
+            }
         }
     }
 
@@ -88,8 +100,87 @@ public final class SourcePatternScanner {
         return false;
     }
 
-    private static String stripLineComment(String line) {
-        var commentStart = line.indexOf("//");
-        return commentStart >= 0 ? line.substring(0, commentStart) : line;
+    private static boolean importsSunMiscUnsafe(List<String> lines) {
+        return lines.stream()
+                .anyMatch(line -> line.stripLeading().matches("import\\s+sun\\.misc\\.Unsafe\\s*;.*"));
+    }
+
+    private static boolean isUnsafeUsage(String line, boolean importsUnsafe) {
+        return line.contains("sun.misc.Unsafe") || (importsUnsafe && UNSAFE_SIMPLE_NAME.matcher(line).find());
+    }
+
+    private static List<String> stripCommentsAndLiterals(List<String> lines) {
+        var sanitizedLines = new ArrayList<String>(lines.size());
+        var inBlockComment = false;
+        var inTextBlock = false;
+        for (String line : lines) {
+            var sanitized = new StringBuilder();
+            for (int index = 0; index < line.length();) {
+                if (inTextBlock) {
+                    var textBlockEnd = line.indexOf("\"\"\"", index);
+                    if (textBlockEnd < 0) {
+                        break;
+                    }
+                    inTextBlock = false;
+                    index = textBlockEnd + 3;
+                    continue;
+                }
+
+                if (inBlockComment) {
+                    if (startsWith(line, index, "*/")) {
+                        inBlockComment = false;
+                        index += 2;
+                    } else {
+                        index++;
+                    }
+                    continue;
+                }
+
+                if (startsWith(line, index, "//")) {
+                    break;
+                }
+                if (startsWith(line, index, "/*")) {
+                    inBlockComment = true;
+                    index += 2;
+                    continue;
+                }
+                if (startsWith(line, index, "\"\"\"")) {
+                    inTextBlock = true;
+                    index += 3;
+                    continue;
+                }
+
+                var current = line.charAt(index);
+                if (current == '"' || current == '\'') {
+                    sanitized.append(' ');
+                    index = skipQuotedLiteral(line, index, current);
+                    continue;
+                }
+
+                sanitized.append(current);
+                index++;
+            }
+            sanitizedLines.add(sanitized.toString());
+        }
+        return List.copyOf(sanitizedLines);
+    }
+
+    private static int skipQuotedLiteral(String line, int startIndex, char quote) {
+        var index = startIndex + 1;
+        while (index < line.length()) {
+            var current = line.charAt(index);
+            if (current == '\\') {
+                index += 2;
+            } else if (current == quote) {
+                return index + 1;
+            } else {
+                index++;
+            }
+        }
+        return index;
+    }
+
+    private static boolean startsWith(String line, int index, String token) {
+        return index + token.length() <= line.length() && line.startsWith(token, index);
     }
 }

--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/SourcePatternType.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/SourcePatternType.java
@@ -4,5 +4,6 @@ public enum SourcePatternType {
     MAP_STRING_OBJECT,
     SIMPLE_DATE_FORMAT,
     EXECUTOR_FACTORY,
-    THREAD_LOCAL
+    THREAD_LOCAL,
+    UNSAFE_MEMORY_ACCESS
 }

--- a/analyzer-core/src/test/java/dev/modernjava/upgrade/core/DefaultAnalyzerTest.java
+++ b/analyzer-core/src/test/java/dev/modernjava/upgrade/core/DefaultAnalyzerTest.java
@@ -217,6 +217,80 @@ class DefaultAnalyzerTest {
     }
 
     @Test
+    void reportsPreviewCompilerArgsAsJava25Boundary() {
+        var metadata = new ProjectMetadata(
+                "gradle",
+                "21",
+                "3.4.4",
+                List.of(),
+                List.of(),
+                List.of("--enable-preview"),
+                List.of());
+        var request = new AnalysisRequest(Path.of("."), 25);
+
+        var result = new DefaultAnalyzer(metadata).analyze(request);
+
+        assertThat(result.findings())
+                .filteredOn(finding -> finding.id().equals("jdk-25-preview-feature-boundary"))
+                .singleElement()
+                .satisfies(finding -> {
+                    assertThat(finding.category()).isEqualTo(FindingCategory.BUILD);
+                    assertThat(finding.severity()).isEqualTo(FindingSeverity.RISK);
+                    assertThat(finding.evidence()).contains("--enable-preview");
+                    assertThat(finding.recommendation())
+                            .contains("explicit technical debt")
+                            .contains("every JDK update");
+                });
+    }
+
+    @Test
+    void doesNotReportPreviewBoundaryOutsideJava21To25Migration() {
+        var metadata = new ProjectMetadata(
+                "gradle",
+                "21",
+                "3.4.4",
+                List.of(),
+                List.of(),
+                List.of("--enable-preview"),
+                List.of());
+
+        var result = new DefaultAnalyzer(metadata).analyze(new AnalysisRequest(Path.of("."), 21));
+
+        assertThat(result.findings())
+                .extracting(Finding::id)
+                .doesNotContain("jdk-25-preview-feature-boundary");
+    }
+
+    @Test
+    void reportsUnsafeUsageForJava21To25Migration() {
+        var metadata = new ProjectMetadata(
+                "maven",
+                "21",
+                "3.4.4",
+                List.of(),
+                List.of(),
+                List.of(new SourcePattern(
+                        SourcePatternType.UNSAFE_MEMORY_ACCESS,
+                        Path.of("src/main/java/example/UnsafeHolder.java"),
+                        6,
+                        "private static final Unsafe UNSAFE = lookupUnsafe();")));
+        var request = new AnalysisRequest(Path.of("."), 25);
+
+        var result = new DefaultAnalyzer(metadata).analyze(request);
+
+        assertThat(result.findings())
+                .filteredOn(finding -> finding.id().equals("source-unsafe-memory-access-src-main-java-example-unsafeholder-java-6"))
+                .singleElement()
+                .satisfies(finding -> {
+                    assertThat(finding.category()).isEqualTo(FindingCategory.BUILD);
+                    assertThat(finding.severity()).isEqualTo(FindingSeverity.RISK);
+                    assertThat(finding.recommendation())
+                            .contains("Remove direct unsafe memory-access usage")
+                            .contains("audit dependencies");
+                });
+    }
+
+    @Test
     void reportsSourceModernizationFindings() {
         var metadata = new ProjectMetadata(
                 "maven",

--- a/analyzer-core/src/test/java/dev/modernjava/upgrade/core/SourcePatternScannerTest.java
+++ b/analyzer-core/src/test/java/dev/modernjava/upgrade/core/SourcePatternScannerTest.java
@@ -111,4 +111,85 @@ class SourcePatternScannerTest {
                 .extracting(SourcePattern::lineNumber)
                 .containsExactly(6);
     }
+
+    @Test
+    void detectsDirectUnsafeUsageOutsideImports() throws Exception {
+        var source = tempDir.resolve("src/main/java/example/UnsafeHolder.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, """
+                package example;
+
+                import sun.misc.Unsafe;
+
+                final class UnsafeHolder {
+                    private static final Unsafe UNSAFE = lookupUnsafe();
+                }
+                """);
+
+        var patterns = new SourcePatternScanner().scan(tempDir);
+
+        assertThat(patterns)
+                .extracting(SourcePattern::type)
+                .containsExactly(SourcePatternType.UNSAFE_MEMORY_ACCESS);
+        assertThat(patterns)
+                .extracting(SourcePattern::lineNumber)
+                .containsExactly(6);
+    }
+
+    @Test
+    void ignoresUnsafeImportsWithoutActionableUsage() throws Exception {
+        var source = tempDir.resolve("src/main/java/example/UnsafeImportOnly.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, """
+                package example;
+
+                import sun.misc.Unsafe;
+
+                final class UnsafeImportOnly {
+                }
+                """);
+
+        var patterns = new SourcePatternScanner().scan(tempDir);
+
+        assertThat(patterns).isEmpty();
+    }
+
+    @Test
+    void ignoresUnsafeTextInStringsAndBlockComments() throws Exception {
+        var source = tempDir.resolve("src/main/java/example/UnsafeText.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, """
+                package example;
+
+                final class UnsafeText {
+                    String text = "sun.misc.Unsafe";
+                    /*
+                     * sun.misc.Unsafe unsafe;
+                     */
+                }
+                """);
+
+        var patterns = new SourcePatternScanner().scan(tempDir);
+
+        assertThat(patterns).isEmpty();
+    }
+
+    @Test
+    void ignoresUnsafeTextInTextBlocks() throws Exception {
+        var source = tempDir.resolve("src/main/java/example/UnsafeTextBlock.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, """
+                package example;
+
+                final class UnsafeTextBlock {
+                    String text = \"""
+                            sun.misc.Unsafe
+                            \""";
+                }
+                """);
+
+        var patterns = new SourcePatternScanner().scan(tempDir);
+
+        assertThat(patterns).isEmpty();
+    }
 }

--- a/build-inspectors/src/main/java/dev/modernjava/upgrade/build/GradleProjectInspector.java
+++ b/build-inspectors/src/main/java/dev/modernjava/upgrade/build/GradleProjectInspector.java
@@ -24,6 +24,13 @@ public final class GradleProjectInspector {
     private static final Pattern BARE_JAVA_PLUGIN = Pattern.compile("^\\s*java\\s*$", Pattern.MULTILINE);
     private static final Pattern DEPENDENCY_COORDINATE = Pattern.compile(
             "\\b(?:implementation|api|compileOnly|runtimeOnly|testImplementation|testRuntimeOnly)\\s*(?:\\(\\s*)?['\"]([^:'\"]+:[^:'\"]+)(?::[^'\"]+)?['\"]");
+    private static final Pattern COMPILER_ARGS_LIST = Pattern.compile(
+            "compilerArgs\\s*(?:=|\\+=)\\s*(?:listOf\\s*\\(|\\[)(.*?)(?:\\)|\\])",
+            Pattern.DOTALL);
+    private static final Pattern COMPILER_ARGS_METHOD = Pattern.compile(
+            "compilerArgs\\.(?:add|addAll)\\s*\\((.*?)\\)",
+            Pattern.DOTALL);
+    private static final Pattern QUOTED_STRING = Pattern.compile("['\"]([^'\"]+)['\"]");
 
     public ProjectMetadata inspect(Path projectPath) {
         var buildFile = resolveBuildFile(Objects.requireNonNull(projectPath, "projectPath"));
@@ -34,7 +41,9 @@ public final class GradleProjectInspector {
                 detectJavaVersion(content),
                 detectSpringBootVersion(content),
                 collectDependencies(content),
-                collectBuildPlugins(content));
+                collectBuildPlugins(content),
+                collectCompilerArgs(content),
+                List.of());
     }
 
     private static Path resolveBuildFile(Path projectPath) {
@@ -99,6 +108,14 @@ public final class GradleProjectInspector {
         return List.copyOf(plugins);
     }
 
+    private static List<String> collectCompilerArgs(String content) {
+        var uncommentedContent = stripComments(content);
+        var compilerArgs = new LinkedHashSet<String>();
+        collectQuotedMatches(uncommentedContent, COMPILER_ARGS_LIST, compilerArgs);
+        collectQuotedMatches(uncommentedContent, COMPILER_ARGS_METHOD, compilerArgs);
+        return List.copyOf(compilerArgs);
+    }
+
     private static String firstMatch(String content, Pattern pattern) {
         var matcher = pattern.matcher(content);
         return matcher.find() ? matcher.group(1).trim() : null;
@@ -111,5 +128,66 @@ public final class GradleProjectInspector {
             matches.add(matcher.group(1).trim());
         }
         return List.copyOf(matches);
+    }
+
+    private static void collectQuotedMatches(String content, Pattern statementPattern, Set<String> matches) {
+        var statementMatcher = statementPattern.matcher(content);
+        while (statementMatcher.find()) {
+            var quotedMatcher = QUOTED_STRING.matcher(statementMatcher.group(1));
+            while (quotedMatcher.find()) {
+                matches.add(quotedMatcher.group(1).trim());
+            }
+        }
+    }
+
+    private static String stripComments(String content) {
+        var stripped = new StringBuilder(content.length());
+        var inBlockComment = false;
+        char quote = 0;
+        var escaped = false;
+        for (int index = 0; index < content.length(); index++) {
+            var current = content.charAt(index);
+            var next = index + 1 < content.length() ? content.charAt(index + 1) : '\0';
+
+            if (inBlockComment) {
+                if (current == '*' && next == '/') {
+                    inBlockComment = false;
+                    index++;
+                } else if (current == '\n') {
+                    stripped.append(current);
+                }
+                continue;
+            }
+
+            if (quote != 0) {
+                stripped.append(current);
+                if (escaped) {
+                    escaped = false;
+                } else if (current == '\\') {
+                    escaped = true;
+                } else if (current == quote) {
+                    quote = 0;
+                }
+                continue;
+            }
+
+            if (current == '"' || current == '\'') {
+                quote = current;
+                stripped.append(current);
+            } else if (current == '/' && next == '/') {
+                while (index < content.length() && content.charAt(index) != '\n') {
+                    index++;
+                }
+                if (index < content.length()) {
+                    stripped.append(content.charAt(index));
+                }
+            } else if (current == '/' && next == '*') {
+                inBlockComment = true;
+                index++;
+            } else {
+                stripped.append(current);
+            }
+        }
+        return stripped.toString();
     }
 }

--- a/build-inspectors/src/main/java/dev/modernjava/upgrade/build/MavenProjectInspector.java
+++ b/build-inspectors/src/main/java/dev/modernjava/upgrade/build/MavenProjectInspector.java
@@ -6,9 +6,11 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
@@ -30,7 +32,9 @@ public final class MavenProjectInspector {
                 detectJavaVersion(model),
                 detectSpringBootVersion(model),
                 collectDependencies(model),
-                collectBuildPlugins(model));
+                collectBuildPlugins(model),
+                collectCompilerArgs(model),
+                List.of());
     }
 
     private static Path resolvePomPath(Path projectPath) {
@@ -164,6 +168,54 @@ public final class MavenProjectInspector {
         return List.copyOf(plugins);
     }
 
+    private static List<String> collectCompilerArgs(Model model) {
+        var build = model.getBuild();
+        if (build == null || build.getPlugins() == null) {
+            return List.of();
+        }
+
+        Set<String> compilerArgs = new LinkedHashSet<>();
+        for (Plugin plugin : build.getPlugins()) {
+            if (!isCompilerPlugin(plugin) || !(plugin.getConfiguration() instanceof Xpp3Dom dom)) {
+                if (isCompilerPlugin(plugin)) {
+                    collectExecutionCompilerArgs(plugin, compilerArgs);
+                }
+                continue;
+            }
+            collectCompilerArgs(dom, compilerArgs);
+            collectExecutionCompilerArgs(plugin, compilerArgs);
+        }
+        return List.copyOf(compilerArgs);
+    }
+
+    private static void collectExecutionCompilerArgs(Plugin plugin, Set<String> compilerArgs) {
+        if (plugin.getExecutions() == null) {
+            return;
+        }
+
+        for (var execution : plugin.getExecutions()) {
+            if (execution.getConfiguration() instanceof Xpp3Dom dom) {
+                collectCompilerArgs(dom, compilerArgs);
+            }
+        }
+    }
+
+    private static void collectCompilerArgs(Xpp3Dom configuration, Set<String> compilerArgs) {
+        var compilerArgsNode = configuration.getChild("compilerArgs");
+        if (compilerArgsNode != null) {
+            for (Xpp3Dom child : compilerArgsNode.getChildren()) {
+                addNonBlank(compilerArgs, child.getValue());
+            }
+        }
+
+        var compilerArgumentNode = configuration.getChild("compilerArgument");
+        if (compilerArgumentNode != null && compilerArgumentNode.getValue() != null) {
+            for (String arg : compilerArgumentNode.getValue().trim().split("\\s+")) {
+                addNonBlank(compilerArgs, arg);
+            }
+        }
+    }
+
     private static String firstNonBlank(Properties properties, String... keys) {
         if (properties == null) {
             return null;
@@ -217,5 +269,11 @@ public final class MavenProjectInspector {
         }
         var normalized = value.trim();
         return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static void addNonBlank(Set<String> values, String value) {
+        if (value != null && !value.isBlank()) {
+            values.add(value.trim());
+        }
     }
 }

--- a/build-inspectors/src/test/java/dev/modernjava/upgrade/build/GradleProjectInspectorTest.java
+++ b/build-inspectors/src/test/java/dev/modernjava/upgrade/build/GradleProjectInspectorTest.java
@@ -45,6 +45,35 @@ class GradleProjectInspectorTest {
     }
 
     @Test
+    void extractsVisibleGroovyGradleCompilerArgs() {
+        var fixturePath = Path.of("src", "test", "resources", "fixtures", "gradle-groovy-java21-preview");
+
+        var metadata = new GradleProjectInspector().inspect(fixturePath);
+
+        assertThat(metadata.declaredJavaVersion()).isEqualTo("21");
+        assertThat(metadata.compilerArgs()).containsExactly("--enable-preview", "-Xlint:preview");
+    }
+
+    @Test
+    void extractsVisibleKotlinGradleCompilerArgs() {
+        var fixturePath = Path.of("src", "test", "resources", "fixtures", "gradle-kotlin-java21-preview");
+
+        var metadata = new GradleProjectInspector().inspect(fixturePath);
+
+        assertThat(metadata.declaredJavaVersion()).isEqualTo("21");
+        assertThat(metadata.compilerArgs()).containsExactly("--enable-preview");
+    }
+
+    @Test
+    void ignoresCommentedGradleCompilerArgs() {
+        var fixturePath = Path.of("src", "test", "resources", "fixtures", "gradle-kotlin-commented-preview");
+
+        var metadata = new GradleProjectInspector().inspect(fixturePath);
+
+        assertThat(metadata.compilerArgs()).isEmpty();
+    }
+
+    @Test
     void rejectsPathsWithoutAGradleBuildFile() {
         var missingPath = Path.of("src", "test", "resources", "fixtures", "missing-gradle-build");
 

--- a/build-inspectors/src/test/java/dev/modernjava/upgrade/build/MavenProjectInspectorTest.java
+++ b/build-inspectors/src/test/java/dev/modernjava/upgrade/build/MavenProjectInspectorTest.java
@@ -22,6 +22,34 @@ class MavenProjectInspectorTest {
     }
 
     @Test
+    void extractsVisibleCompilerArgsFromMavenCompilerPlugin() {
+        var fixturePath = Path.of("src", "test", "resources", "fixtures", "maven-java21-preview");
+
+        var metadata = new MavenProjectInspector().inspect(fixturePath);
+
+        assertThat(metadata.declaredJavaVersion()).isEqualTo("21");
+        assertThat(metadata.compilerArgs()).containsExactly("--enable-preview", "-Xlint:preview");
+    }
+
+    @Test
+    void extractsLegacyMavenCompilerArgumentText() {
+        var fixturePath = Path.of("src", "test", "resources", "fixtures", "maven-java21-preview-legacy");
+
+        var metadata = new MavenProjectInspector().inspect(fixturePath);
+
+        assertThat(metadata.compilerArgs()).containsExactly("--enable-preview", "-Xlint:preview");
+    }
+
+    @Test
+    void extractsCompilerArgsFromVisibleMavenCompilerPluginExecution() {
+        var fixturePath = Path.of("src", "test", "resources", "fixtures", "maven-java21-preview-execution");
+
+        var metadata = new MavenProjectInspector().inspect(fixturePath);
+
+        assertThat(metadata.compilerArgs()).containsExactly("--enable-preview");
+    }
+
+    @Test
     void rejectsPathsWithoutAPomXmlFile() {
         var missingPath = Path.of("src", "test", "resources", "fixtures", "missing-pom");
 

--- a/build-inspectors/src/test/resources/fixtures/gradle-groovy-java21-preview/build.gradle
+++ b/build-inspectors/src/test/resources/fixtures/gradle-groovy-java21-preview/build.gradle
@@ -1,0 +1,10 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.3.5'
+}
+
+sourceCompatibility = '21'
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += ['--enable-preview', '-Xlint:preview']
+}

--- a/build-inspectors/src/test/resources/fixtures/gradle-kotlin-commented-preview/build.gradle.kts
+++ b/build-inspectors/src/test/resources/fixtures/gradle-kotlin-commented-preview/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    java
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+// options.compilerArgs.add("--enable-preview")
+/*
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("--enable-preview")
+}
+*/

--- a/build-inspectors/src/test/resources/fixtures/gradle-kotlin-java21-preview/build.gradle.kts
+++ b/build-inspectors/src/test/resources/fixtures/gradle-kotlin-java21-preview/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    java
+    id("org.springframework.boot") version "3.3.5"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("--enable-preview")
+}

--- a/build-inspectors/src/test/resources/fixtures/maven-java21-preview-execution/pom.xml
+++ b/build-inspectors/src/test/resources/fixtures/maven-java21-preview-execution/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.modernjava.upgrade.fixtures</groupId>
+    <artifactId>maven-java21-preview-execution</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--enable-preview</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/build-inspectors/src/test/resources/fixtures/maven-java21-preview-legacy/pom.xml
+++ b/build-inspectors/src/test/resources/fixtures/maven-java21-preview-legacy/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.modernjava.upgrade.fixtures</groupId>
+    <artifactId>maven-java21-preview-legacy</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>21</release>
+                    <compilerArgument>--enable-preview -Xlint:preview</compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/build-inspectors/src/test/resources/fixtures/maven-java21-preview/pom.xml
+++ b/build-inspectors/src/test/resources/fixtures/maven-java21-preview/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.modernjava.upgrade.fixtures</groupId>
+    <artifactId>maven-java21-preview</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>21</release>
+                    <compilerArgs>
+                        <arg>--enable-preview</arg>
+                        <arg>-Xlint:preview</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/cli/src/main/java/dev/modernjava/upgrade/cli/AnalyzeCommand.java
+++ b/cli/src/main/java/dev/modernjava/upgrade/cli/AnalyzeCommand.java
@@ -47,6 +47,7 @@ public final class AnalyzeCommand implements Callable<Integer> {
                     inspectedMetadata.springBootVersion(),
                     inspectedMetadata.dependencies(),
                     inspectedMetadata.buildPlugins(),
+                    inspectedMetadata.compilerArgs(),
                     sourcePatterns);
             var result = new DefaultAnalyzer(metadata).analyze(request);
             var markdown = new MarkdownReportRenderer().render(request, result);

--- a/cli/src/test/java/dev/modernjava/upgrade/cli/AnalyzeCommandTest.java
+++ b/cli/src/test/java/dev/modernjava/upgrade/cli/AnalyzeCommandTest.java
@@ -81,6 +81,41 @@ class AnalyzeCommandTest {
     }
 
     @Test
+    void analyzeCommandPreservesCompilerArgsWhenRenderingPreviewBoundary() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        CommandLine commandLine = new CommandLine(new ModernJavaUpgradeLabApp());
+        commandLine.setOut(new PrintWriter(output, true));
+        var buildFile = tempDir.resolve("build.gradle.kts");
+        Files.writeString(buildFile, """
+                plugins {
+                    java
+                }
+
+                java {
+                    toolchain {
+                        languageVersion = JavaLanguageVersion.of(21)
+                    }
+                }
+
+                tasks.withType<JavaCompile>().configureEach {
+                    options.compilerArgs.add("--enable-preview")
+                }
+                """);
+
+        int exitCode = commandLine.execute(
+                "analyze",
+                "--path",
+                tempDir.toString(),
+                "--target",
+                "25");
+
+        assertThat(exitCode).isZero();
+        assertThat(output.toString(StandardCharsets.UTF_8))
+                .contains("Preview feature usage is a Java 25 migration boundary")
+                .contains("--enable-preview");
+    }
+
+    @Test
     void analyzeCommandWritesReportToOutputFile() throws Exception {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         CommandLine commandLine = new CommandLine(new ModernJavaUpgradeLabApp());


### PR DESCRIPTION
## Summary

- Capture visible Maven and Gradle compiler arguments in project metadata.
- Report Java 25 preview-feature boundaries for Java 21 to 25 migrations when `--enable-preview` is detected.
- Report direct `sun.misc.Unsafe` source usage with source evidence and preserve compiler args through the CLI path.

## Validation

- `mvn clean test '-Dmaven.compiler.release=22'` passes with 51 tests.
- `mvn clean test` without the override fails locally because the active JDK is 22 while the root POM requests release 25.

Closes #12
Closes #15
Closes #16
Closes #17