### PR TITLE
Update Java 21 to 25 sample report

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ During MVP development, the repository is organized around these current and pla
 - `reports/` - sample generated reports.
 - `docs/` - vision, roadmap, blog ideas, contribution guides, and the engineering log.
 
+Sample reports:
+
+- [Spring Boot 3 Gradle Java 21 to Java 25](reports/sample-spring-boot-3-gradle-java-21-to-java-25.md)
+- [Spring Boot 2 Maven Java 8 to Java 21](reports/sample-spring-boot-2-java-8-to-java-21.md)
+
 ## Contributing
 
 Good first contributions include:

--- a/examples/spring-boot-3-gradle-java-21/src/main/java/dev/modernjava/upgrade/example/RequestContext.java
+++ b/examples/spring-boot-3-gradle-java-21/src/main/java/dev/modernjava/upgrade/example/RequestContext.java
@@ -1,0 +1,17 @@
+package dev.modernjava.upgrade.example;
+
+final class RequestContext {
+
+    private static final ThreadLocal<String> TENANT = new ThreadLocal<>();
+
+    private RequestContext() {
+    }
+
+    static void setTenant(String tenant) {
+        TENANT.set(tenant);
+    }
+
+    static void clear() {
+        TENANT.remove();
+    }
+}

--- a/reports/sample-spring-boot-3-gradle-java-21-to-java-25.md
+++ b/reports/sample-spring-boot-3-gradle-java-21-to-java-25.md
@@ -17,6 +17,14 @@ Project path: `examples/spring-boot-3-gradle-java-21`
 - Evidence: src\main\java\dev\modernjava\upgrade\example\GradleGreetingController.java:11 contains `Map<String, Object> hello() {`
 - Recommendation: Review whether this loosely typed map represents a stable response shape. If it does, model it as a DTO now and consider a record when the target runtime supports it.
 
+## Concurrency
+
+### [INFO] ThreadLocal usage should be reviewed for scoped values
+
+- Area: Concurrency modernization
+- Evidence: src\main\java\dev\modernjava\upgrade\example\RequestContext.java:5 contains `private static final ThreadLocal<String> TENANT = new ThreadLocal<>();`
+- Recommendation: Review whether this context propagation can move toward scoped values on Java 25. Do not rewrite automatically; validate lifecycle, framework integration, and request boundaries first.
+
 ## Automation Suggestions
 
 ### [INFO] OpenRewrite has a Java 25 migration recipe
@@ -26,3 +34,11 @@ Project path: `examples/spring-boot-3-gradle-java-21`
 - Recommendation: Review and run the suggested OpenRewrite recipe in a branch before manual changes.
 - OpenRewrite recipe: `org.openrewrite.java.migrate.UpgradeToJava25`
 - OpenRewrite command: `mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:RELEASE -Drewrite.activeRecipes=org.openrewrite.java.migrate.UpgradeToJava25 -Drewrite.exportDatatables=true`
+
+## Baseline & Planning
+
+### [INFO] Java 21 to 25 migration should start with a build and test baseline
+
+- Area: Java baseline
+- Evidence: Declared Java version is 21; target Java version is 25
+- Recommendation: Establish a Java 25 build and test baseline before enabling optional language, runtime, GC, JFR, or AOT changes.


### PR DESCRIPTION
## Summary

- Add a Java 21 sample `ThreadLocal` source signal to the Gradle example.
- Regenerate the Java 21 to 25 sample report with baseline and concurrency sections.
- Link the checked-in sample reports from the README.

## Validation

- `mvn clean test '-Dmaven.compiler.release=22'` passes with 51 tests.

Closes #13