### PR TITLE
Implement Gradle version catalog inspection

### DIFF
--- a/build-inspectors/pom.xml
+++ b/build-inspectors/pom.xml
@@ -25,6 +25,11 @@
             <version>${maven.model.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.tomlj</groupId>
+            <artifactId>tomlj</artifactId>
+            <version>${tomlj.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/build-inspectors/src/main/java/dev/modernjava/upgrade/build/GradleProjectInspector.java
+++ b/build-inspectors/src/main/java/dev/modernjava/upgrade/build/GradleProjectInspector.java
@@ -24,6 +24,11 @@ public final class GradleProjectInspector {
     private static final Pattern BARE_JAVA_PLUGIN = Pattern.compile("^\\s*java\\s*$", Pattern.MULTILINE);
     private static final Pattern DEPENDENCY_COORDINATE = Pattern.compile(
             "\\b(?:implementation|api|compileOnly|runtimeOnly|testImplementation|testRuntimeOnly)\\s*(?:\\(\\s*)?['\"]([^:'\"]+:[^:'\"]+)(?::[^'\"]+)?['\"]");
+    private static final Pattern DEPENDENCY_CATALOG_REFERENCE = Pattern.compile(
+            "\\b(?:implementation|api|compileOnly|runtimeOnly|testImplementation|testRuntimeOnly)\\s*(?:\\(\\s*)?"
+                    + "(libs(?:\\.[A-Za-z][A-Za-z0-9_-]*)+)\\b");
+    static final Pattern PLUGIN_CATALOG_REFERENCE = Pattern.compile(
+            "\\balias\\s*(?:\\(\\s*)?(libs\\.plugins(?:\\.[A-Za-z][A-Za-z0-9_-]*)+)\\b");
     private static final Pattern COMPILER_ARGS_LIST = Pattern.compile(
             "compilerArgs\\s*(?:=|\\+=)\\s*(?:listOf\\s*\\(|\\[)(.*?)(?:\\)|\\])",
             Pattern.DOTALL);
@@ -35,13 +40,14 @@ public final class GradleProjectInspector {
     public ProjectMetadata inspect(Path projectPath) {
         var buildFile = resolveBuildFile(Objects.requireNonNull(projectPath, "projectPath"));
         var content = readBuildFile(buildFile);
+        var catalog = GradleVersionCatalog.read(resolveProjectRoot(projectPath, buildFile));
 
         return new ProjectMetadata(
                 "gradle",
                 detectJavaVersion(content),
-                detectSpringBootVersion(content),
-                collectDependencies(content),
-                collectBuildPlugins(content),
+                detectSpringBootVersion(content, catalog),
+                collectDependencies(content, catalog),
+                collectBuildPlugins(content, catalog),
                 collectCompilerArgs(content),
                 List.of());
     }
@@ -70,6 +76,13 @@ public final class GradleProjectInspector {
         return "build.gradle".equals(fileName) || "build.gradle.kts".equals(fileName);
     }
 
+    private static Path resolveProjectRoot(Path projectPath, Path buildFile) {
+        if (Files.isRegularFile(projectPath) && isGradleBuildFile(projectPath)) {
+            return buildFile.toAbsolutePath().normalize().getParent();
+        }
+        return projectPath.toAbsolutePath().normalize();
+    }
+
     private static String readBuildFile(Path buildFile) {
         try {
             return Files.readString(buildFile);
@@ -90,20 +103,30 @@ public final class GradleProjectInspector {
         return version == null ? "unknown" : version;
     }
 
-    private static String detectSpringBootVersion(String content) {
-        return firstMatch(content, SPRING_BOOT_PLUGIN);
+    private static String detectSpringBootVersion(String content, GradleVersionCatalog catalog) {
+        var directVersion = firstMatch(content, SPRING_BOOT_PLUGIN);
+        return directVersion == null ? catalog.springBootVersion(content) : directVersion;
     }
 
-    private static List<String> collectDependencies(String content) {
-        return collectMatches(content, DEPENDENCY_COORDINATE);
+    private static List<String> collectDependencies(String content, GradleVersionCatalog catalog) {
+        var dependencies = new LinkedHashSet<>(collectMatches(content, DEPENDENCY_COORDINATE));
+        var matcher = DEPENDENCY_CATALOG_REFERENCE.matcher(content);
+        while (matcher.find()) {
+            catalog.addDependencies(matcher.group(1), dependencies);
+        }
+        return List.copyOf(dependencies);
     }
 
-    private static List<String> collectBuildPlugins(String content) {
+    private static List<String> collectBuildPlugins(String content, GradleVersionCatalog catalog) {
         var plugins = new LinkedHashSet<String>();
         plugins.addAll(collectMatches(content, GROOVY_PLUGIN_ID));
         plugins.addAll(collectMatches(content, KOTLIN_PLUGIN_ID));
         if (BARE_JAVA_PLUGIN.matcher(content).find()) {
             plugins.add("java");
+        }
+        var matcher = PLUGIN_CATALOG_REFERENCE.matcher(content);
+        while (matcher.find()) {
+            catalog.addPlugin(matcher.group(1), plugins);
         }
         return List.copyOf(plugins);
     }

--- a/build-inspectors/src/main/java/dev/modernjava/upgrade/build/GradleVersionCatalog.java
+++ b/build-inspectors/src/main/java/dev/modernjava/upgrade/build/GradleVersionCatalog.java
@@ -1,0 +1,211 @@
+package dev.modernjava.upgrade.build;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.tomlj.Toml;
+import org.tomlj.TomlArray;
+import org.tomlj.TomlParseResult;
+import org.tomlj.TomlTable;
+
+final class GradleVersionCatalog {
+
+    private static final GradleVersionCatalog EMPTY =
+            new GradleVersionCatalog(Map.of(), Map.of(), Map.of());
+
+    private final Map<String, CatalogLibrary> libraries;
+    private final Map<String, CatalogPlugin> plugins;
+    private final Map<String, List<String>> bundles;
+
+    private GradleVersionCatalog(
+            Map<String, CatalogLibrary> libraries,
+            Map<String, CatalogPlugin> plugins,
+            Map<String, List<String>> bundles) {
+        this.libraries = libraries;
+        this.plugins = plugins;
+        this.bundles = bundles;
+    }
+
+    static GradleVersionCatalog read(Path projectRoot) {
+        var catalogFile = projectRoot.resolve("gradle").resolve("libs.versions.toml");
+        if (!Files.isRegularFile(catalogFile)) {
+            return EMPTY;
+        }
+
+        TomlParseResult result;
+        try {
+            result = Toml.parse(Files.readString(catalogFile));
+        } catch (IOException exception) {
+            return EMPTY;
+        }
+        if (result.hasErrors()) {
+            return EMPTY;
+        }
+
+        var versions = collectVersions(result);
+        return new GradleVersionCatalog(
+                collectLibraries(result),
+                collectPlugins(result, versions),
+                collectBundles(result));
+    }
+
+    void addDependencies(String reference, Set<String> dependencies) {
+        if (reference.startsWith("libs.bundles.")) {
+            var bundle = bundles.get(reference.substring("libs.bundles.".length()));
+            if (bundle == null) {
+                return;
+            }
+            for (String alias : bundle) {
+                var library = libraries.get(alias);
+                if (library != null) {
+                    dependencies.add(library.coordinate());
+                }
+            }
+            return;
+        }
+
+        var library = libraries.get(reference.substring("libs.".length()));
+        if (library != null) {
+            dependencies.add(library.coordinate());
+        }
+    }
+
+    void addPlugin(String reference, Set<String> buildPlugins) {
+        var plugin = plugins.get(reference.substring("libs.plugins.".length()));
+        if (plugin != null) {
+            buildPlugins.add(plugin.id());
+        }
+    }
+
+    String springBootVersion(String content) {
+        var matcher = GradleProjectInspector.PLUGIN_CATALOG_REFERENCE.matcher(content);
+        while (matcher.find()) {
+            var plugin = plugins.get(matcher.group(1).substring("libs.plugins.".length()));
+            if (plugin != null && "org.springframework.boot".equals(plugin.id())) {
+                return plugin.version();
+            }
+        }
+        return null;
+    }
+
+    private static Map<String, String> collectVersions(TomlTable catalog) {
+        var versionsTable = catalog.getTable("versions");
+        if (versionsTable == null) {
+            return Map.of();
+        }
+
+        var versions = new java.util.LinkedHashMap<String, String>();
+        for (var entry : versionsTable.entrySet()) {
+            if (entry.getValue() instanceof String version) {
+                versions.put(entry.getKey(), version);
+                versions.put(normalizeAlias(entry.getKey()), version);
+            }
+        }
+        return Map.copyOf(versions);
+    }
+
+    private static Map<String, CatalogLibrary> collectLibraries(TomlTable catalog) {
+        var librariesTable = catalog.getTable("libraries");
+        if (librariesTable == null) {
+            return Map.of();
+        }
+
+        var libraries = new java.util.LinkedHashMap<String, CatalogLibrary>();
+        for (var entry : librariesTable.entrySet()) {
+            var coordinate = libraryCoordinate(entry.getValue());
+            if (coordinate != null) {
+                libraries.put(normalizeAlias(entry.getKey()), new CatalogLibrary(coordinate));
+            }
+        }
+        return Map.copyOf(libraries);
+    }
+
+    private static String libraryCoordinate(Object value) {
+        if (value instanceof String coordinate) {
+            return groupAndName(coordinate);
+        }
+        if (!(value instanceof TomlTable table)) {
+            return null;
+        }
+
+        if (table.isString("module")) {
+            return groupAndName(table.getString("module"));
+        }
+
+        if (table.isString("group") && table.isString("name")) {
+            return table.getString("group") + ":" + table.getString("name");
+        }
+        return null;
+    }
+
+    private static String groupAndName(String coordinate) {
+        var parts = coordinate.split(":");
+        if (parts.length < 2 || parts[0].isBlank() || parts[1].isBlank()) {
+            return null;
+        }
+        return parts[0].trim() + ":" + parts[1].trim();
+    }
+
+    private static Map<String, CatalogPlugin> collectPlugins(TomlTable catalog, Map<String, String> versions) {
+        var pluginsTable = catalog.getTable("plugins");
+        if (pluginsTable == null) {
+            return Map.of();
+        }
+
+        var plugins = new java.util.LinkedHashMap<String, CatalogPlugin>();
+        for (var entry : pluginsTable.entrySet()) {
+            if (entry.getValue() instanceof TomlTable table && table.isString("id")) {
+                plugins.put(normalizeAlias(entry.getKey()), new CatalogPlugin(
+                        table.getString("id"),
+                        pluginVersion(table, versions)));
+            }
+        }
+        return Map.copyOf(plugins);
+    }
+
+    private static String pluginVersion(TomlTable plugin, Map<String, String> versions) {
+        if (plugin.isString("version")) {
+            return plugin.getString("version");
+        }
+
+        if (!plugin.isString("version.ref")) {
+            return null;
+        }
+
+        var versionRef = plugin.getString("version.ref");
+        return versions.getOrDefault(versionRef, versions.get(normalizeAlias(versionRef)));
+    }
+
+    private static Map<String, List<String>> collectBundles(TomlTable catalog) {
+        var bundlesTable = catalog.getTable("bundles");
+        if (bundlesTable == null) {
+            return Map.of();
+        }
+
+        var bundles = new java.util.LinkedHashMap<String, List<String>>();
+        for (var entry : bundlesTable.entrySet()) {
+            if (entry.getValue() instanceof TomlArray array) {
+                var aliases = array.toList().stream()
+                        .filter(String.class::isInstance)
+                        .map(String.class::cast)
+                        .map(GradleVersionCatalog::normalizeAlias)
+                        .toList();
+                bundles.put(normalizeAlias(entry.getKey()), aliases);
+            }
+        }
+        return Map.copyOf(bundles);
+    }
+
+    private static String normalizeAlias(String alias) {
+        return alias.trim().replace('-', '.').replace('_', '.');
+    }
+
+    private record CatalogLibrary(String coordinate) {
+    }
+
+    private record CatalogPlugin(String id, String version) {
+    }
+}

--- a/build-inspectors/src/test/java/dev/modernjava/upgrade/build/GradleProjectInspectorTest.java
+++ b/build-inspectors/src/test/java/dev/modernjava/upgrade/build/GradleProjectInspectorTest.java
@@ -45,6 +45,66 @@ class GradleProjectInspectorTest {
     }
 
     @Test
+    void resolvesKotlinVersionCatalogPluginLibraryAndBundleAliases() {
+        var fixturePath = Path.of("src", "test", "resources", "fixtures", "gradle-kotlin-version-catalog");
+
+        var metadata = new GradleProjectInspector().inspect(fixturePath);
+
+        assertThat(metadata.buildTool()).isEqualTo("gradle");
+        assertThat(metadata.declaredJavaVersion()).isEqualTo("21");
+        assertThat(metadata.springBootVersion()).isEqualTo("3.3.5");
+        assertThat(metadata.dependencies()).containsExactly(
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.assertj:assertj-core");
+        assertThat(metadata.buildPlugins()).contains(
+                "java",
+                "org.springframework.boot",
+                "io.spring.dependency-management");
+    }
+
+    @Test
+    void resolvesGroovyVersionCatalogPluginLibraryAndBundleAliases() {
+        var fixturePath = Path.of("src", "test", "resources", "fixtures", "gradle-groovy-version-catalog");
+
+        var metadata = new GradleProjectInspector().inspect(fixturePath);
+
+        assertThat(metadata.buildTool()).isEqualTo("gradle");
+        assertThat(metadata.declaredJavaVersion()).isEqualTo("17");
+        assertThat(metadata.springBootVersion()).isEqualTo("2.7.18");
+        assertThat(metadata.dependencies()).containsExactly(
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.assertj:assertj-core");
+        assertThat(metadata.buildPlugins()).contains(
+                "java",
+                "org.springframework.boot",
+                "io.spring.dependency-management");
+    }
+
+    @Test
+    void ignoresUnresolvedVersionCatalogAliases() {
+        var fixturePath = Path.of("src", "test", "resources", "fixtures", "gradle-kotlin-version-catalog-unresolved");
+
+        var metadata = new GradleProjectInspector().inspect(fixturePath);
+
+        assertThat(metadata.dependencies()).containsExactly("org.springframework.boot:spring-boot-starter-web");
+        assertThat(metadata.buildPlugins()).containsExactly("java");
+    }
+
+    @Test
+    void keepsVisibleBuildFileInspectionWhenVersionCatalogIsMalformed() {
+        var fixturePath = Path.of("src", "test", "resources", "fixtures", "gradle-kotlin-malformed-version-catalog");
+
+        var metadata = new GradleProjectInspector().inspect(fixturePath);
+
+        assertThat(metadata.declaredJavaVersion()).isEqualTo("21");
+        assertThat(metadata.springBootVersion()).isEqualTo("3.3.5");
+        assertThat(metadata.dependencies()).containsExactly("org.springframework.boot:spring-boot-starter-web");
+        assertThat(metadata.buildPlugins()).contains("java", "org.springframework.boot");
+    }
+
+    @Test
     void extractsVisibleGroovyGradleCompilerArgs() {
         var fixturePath = Path.of("src", "test", "resources", "fixtures", "gradle-groovy-java21-preview");
 

--- a/build-inspectors/src/test/resources/fixtures/gradle-groovy-version-catalog/build.gradle
+++ b/build-inspectors/src/test/resources/fixtures/gradle-groovy-version-catalog/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'java'
+    alias libs.plugins.spring.boot
+    alias libs.plugins.dependency.management
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+dependencies {
+    implementation libs.spring.boot.starter.web
+    testImplementation libs.bundles.testing
+}

--- a/build-inspectors/src/test/resources/fixtures/gradle-groovy-version-catalog/gradle/libs.versions.toml
+++ b/build-inspectors/src/test/resources/fixtures/gradle-groovy-version-catalog/gradle/libs.versions.toml
@@ -1,0 +1,16 @@
+[versions]
+springBoot = "2.7.18"
+dependencyManagement = "1.1.6"
+assertj = "3.26.3"
+
+[libraries]
+spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+
+[bundles]
+testing = ["spring-boot-starter-test", "assertj-core"]
+
+[plugins]
+spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }
+dependency-management = { id = "io.spring.dependency-management", version.ref = "dependencyManagement" }

--- a/build-inspectors/src/test/resources/fixtures/gradle-kotlin-malformed-version-catalog/build.gradle.kts
+++ b/build-inspectors/src/test/resources/fixtures/gradle-kotlin-malformed-version-catalog/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    java
+    id("org.springframework.boot") version "3.3.5"
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation(libs.spring.boot.starter.test)
+}

--- a/build-inspectors/src/test/resources/fixtures/gradle-kotlin-malformed-version-catalog/gradle/libs.versions.toml
+++ b/build-inspectors/src/test/resources/fixtures/gradle-kotlin-malformed-version-catalog/gradle/libs.versions.toml
@@ -1,0 +1,2 @@
+[libraries]
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test"

--- a/build-inspectors/src/test/resources/fixtures/gradle-kotlin-version-catalog-unresolved/build.gradle.kts
+++ b/build-inspectors/src/test/resources/fixtures/gradle-kotlin-version-catalog-unresolved/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    java
+    alias(libs.plugins.missing.plugin)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation(libs.missing.library)
+}

--- a/build-inspectors/src/test/resources/fixtures/gradle-kotlin-version-catalog-unresolved/gradle/libs.versions.toml
+++ b/build-inspectors/src/test/resources/fixtures/gradle-kotlin-version-catalog-unresolved/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[libraries]
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+
+[plugins]
+spring-boot = { id = "org.springframework.boot", version = "3.3.5" }

--- a/build-inspectors/src/test/resources/fixtures/gradle-kotlin-version-catalog/build.gradle.kts
+++ b/build-inspectors/src/test/resources/fixtures/gradle-kotlin-version-catalog/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    java
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.dependency.management)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+dependencies {
+    implementation(libs.spring.boot.starter.web)
+    testImplementation(libs.bundles.testing)
+}

--- a/build-inspectors/src/test/resources/fixtures/gradle-kotlin-version-catalog/gradle/libs.versions.toml
+++ b/build-inspectors/src/test/resources/fixtures/gradle-kotlin-version-catalog/gradle/libs.versions.toml
@@ -1,0 +1,16 @@
+[versions]
+springBoot = "3.3.5"
+dependencyManagement = "1.1.6"
+assertj = "3.26.3"
+
+[libraries]
+spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+
+[bundles]
+testing = ["spring-boot-starter-test", "assertj-core"]
+
+[plugins]
+spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }
+dependency-management = { id = "io.spring.dependency-management", version.ref = "dependencyManagement" }

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <assertj.version>3.26.3</assertj.version>
         <picocli.version>4.7.6</picocli.version>
         <maven.model.version>3.9.9</maven.model.version>
+        <tomlj.version>1.1.1</tomlj.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary

- Add read-only parsing for conventional `gradle/libs.versions.toml` via `org.tomlj:tomlj`.
- Resolve visible Kotlin and Groovy DSL catalog references for libraries, plugins, and bundles.
- Populate existing metadata with resolved `group:name` dependencies, plugin ids, and Spring Boot plugin versions.
- Ignore unresolved aliases and malformed TOML so visible build-file inspection still works.

## Validation

- RED: `mvn -pl build-inspectors -am '-Dtest=GradleProjectInspectorTest' '-Dsurefire.failIfNoSpecifiedTests=false' test '-Dmaven.compiler.release=22'` failed on missing catalog Spring Boot version evidence before implementation.
- `mvn -pl build-inspectors -am test '-Dmaven.compiler.release=22'`
- `mvn clean test '-Dmaven.compiler.release=22'`
- `mvn -pl build-inspectors test '-Dmaven.compiler.release=22'`

Closes #24.