### PR TITLE
Add inspector diagnostics to reports

### DIFF
--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/InspectorDiagnostic.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/InspectorDiagnostic.java
@@ -1,0 +1,29 @@
+package dev.modernjava.upgrade.core;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+public record InspectorDiagnostic(
+        String source,
+        InspectorDiagnosticSeverity severity,
+        String message,
+        Path path) {
+
+    public InspectorDiagnostic {
+        source = normalizeRequiredText(source, "source");
+        severity = Objects.requireNonNull(severity, "severity");
+        message = normalizeRequiredText(message, "message");
+    }
+
+    private static String normalizeRequiredText(String value, String fieldName) {
+        var normalized = Objects.requireNonNull(value, fieldName)
+                .replace('\r', ' ')
+                .replace('\n', ' ')
+                .replaceAll(" +", " ")
+                .trim();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return normalized;
+    }
+}

--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/InspectorDiagnosticSeverity.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/InspectorDiagnosticSeverity.java
@@ -1,0 +1,6 @@
+package dev.modernjava.upgrade.core;
+
+public enum InspectorDiagnosticSeverity {
+    INFO,
+    WARNING
+}

--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/MarkdownReportRenderer.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/MarkdownReportRenderer.java
@@ -23,6 +23,7 @@ public class MarkdownReportRenderer {
         report.append("- Declared Java version: ").append(displayValue(metadata.declaredJavaVersion())).append('\n');
         report.append("- Target Java version: ").append(result.targetJavaVersion()).append('\n');
         report.append("- Spring Boot version: ").append(displayValue(metadata.springBootVersion())).append('\n');
+        appendDiagnostics(report, metadata.diagnostics());
 
         List<Finding> findings = result.findings();
         if (findings.isEmpty()) {
@@ -44,6 +45,25 @@ public class MarkdownReportRenderer {
         }
 
         return report.toString().stripTrailing();
+    }
+
+    private static void appendDiagnostics(StringBuilder report, List<InspectorDiagnostic> diagnostics) {
+        if (diagnostics.isEmpty()) {
+            return;
+        }
+
+        report.append("\n## Inspection Diagnostics\n\n");
+        for (InspectorDiagnostic diagnostic : diagnostics) {
+            report.append("### [")
+                    .append(displayValue(diagnostic.severity().name()))
+                    .append("] ")
+                    .append(displayValue(diagnostic.source()))
+                    .append("\n\n");
+            report.append("- Message: ").append(displayText(diagnostic.message())).append('\n');
+            if (diagnostic.path() != null) {
+                report.append("- Path: `").append(displayText(diagnostic.path().toString())).append("`\n");
+            }
+        }
     }
 
     private static void appendFinding(StringBuilder report, Finding finding) {

--- a/analyzer-core/src/main/java/dev/modernjava/upgrade/core/ProjectMetadata.java
+++ b/analyzer-core/src/main/java/dev/modernjava/upgrade/core/ProjectMetadata.java
@@ -10,7 +10,8 @@ public record ProjectMetadata(
         List<String> dependencies,
         List<String> buildPlugins,
         List<String> compilerArgs,
-        List<SourcePattern> sourcePatterns) {
+        List<SourcePattern> sourcePatterns,
+        List<InspectorDiagnostic> diagnostics) {
 
     public ProjectMetadata {
         buildTool = Objects.requireNonNull(buildTool, "buildTool");
@@ -20,21 +21,28 @@ public record ProjectMetadata(
         buildPlugins = List.copyOf(Objects.requireNonNull(buildPlugins, "buildPlugins"));
         compilerArgs = List.copyOf(Objects.requireNonNull(compilerArgs, "compilerArgs"));
         sourcePatterns = List.copyOf(Objects.requireNonNull(sourcePatterns, "sourcePatterns"));
+        diagnostics = List.copyOf(Objects.requireNonNull(diagnostics, "diagnostics"));
     }
 
     public ProjectMetadata(String buildTool, String declaredJavaVersion, String springBootVersion,
             List<String> dependencies, List<String> buildPlugins) {
-        this(buildTool, declaredJavaVersion, springBootVersion, dependencies, buildPlugins, List.of(), List.of());
+        this(buildTool, declaredJavaVersion, springBootVersion, dependencies, buildPlugins, List.of(), List.of(), List.of());
     }
 
     public ProjectMetadata(String buildTool, String declaredJavaVersion, String springBootVersion,
             List<String> dependencies, List<String> buildPlugins, List<SourcePattern> sourcePatterns) {
-        this(buildTool, declaredJavaVersion, springBootVersion, dependencies, buildPlugins, List.of(), sourcePatterns);
+        this(buildTool, declaredJavaVersion, springBootVersion, dependencies, buildPlugins, List.of(), sourcePatterns, List.of());
+    }
+
+    public ProjectMetadata(String buildTool, String declaredJavaVersion, String springBootVersion,
+            List<String> dependencies, List<String> buildPlugins, List<String> compilerArgs,
+            List<SourcePattern> sourcePatterns) {
+        this(buildTool, declaredJavaVersion, springBootVersion, dependencies, buildPlugins, compilerArgs, sourcePatterns, List.of());
     }
 
     public ProjectMetadata(String buildTool, String declaredJavaVersion, String springBootVersion,
             List<String> dependencies) {
-        this(buildTool, declaredJavaVersion, springBootVersion, dependencies, List.of(), List.of(), List.of());
+        this(buildTool, declaredJavaVersion, springBootVersion, dependencies, List.of(), List.of(), List.of(), List.of());
     }
 
     private static String normalizeOptionalText(String value) {

--- a/analyzer-core/src/test/java/dev/modernjava/upgrade/core/MarkdownReportRendererTest.java
+++ b/analyzer-core/src/test/java/dev/modernjava/upgrade/core/MarkdownReportRendererTest.java
@@ -73,6 +73,38 @@ class MarkdownReportRendererTest {
     }
 
     @Test
+    void rendersInspectionDiagnosticsInDedicatedSection() {
+        var request = new AnalysisRequest(Path.of("/workspace/sample-project"), 25);
+        var metadata = new ProjectMetadata(
+                "gradle",
+                "21",
+                "3.3.5",
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(new InspectorDiagnostic(
+                        "Gradle version catalog",
+                        InspectorDiagnosticSeverity.WARNING,
+                        "Could not parse version catalog; catalog aliases were skipped.",
+                        Path.of("gradle", "libs.versions.toml"))));
+        var result = new AnalysisResult(metadata, 25, List.of());
+
+        var report = new MarkdownReportRenderer().render(request, result);
+
+        assertThat(report).contains(
+                """
+                ## Inspection Diagnostics
+
+                ### [WARNING] Gradle version catalog
+
+                - Message: Could not parse version catalog; catalog aliases were skipped.
+                - Path: `%s`
+                """.formatted(Path.of("gradle", "libs.versions.toml")).stripTrailing());
+        assertThat(report).contains("No findings were generated yet.");
+    }
+
+    @Test
     void omitsOpenRewriteRecipeLineWhenRecipeIsMissing() {
         var request = new AnalysisRequest(Path.of("/workspace/sample-project"), 21);
         var metadata = new ProjectMetadata(

--- a/build-inspectors/src/main/java/dev/modernjava/upgrade/build/GradleProjectInspector.java
+++ b/build-inspectors/src/main/java/dev/modernjava/upgrade/build/GradleProjectInspector.java
@@ -49,7 +49,8 @@ public final class GradleProjectInspector {
                 collectDependencies(content, catalog),
                 collectBuildPlugins(content, catalog),
                 collectCompilerArgs(content),
-                List.of());
+                List.of(),
+                catalog.diagnostics());
     }
 
     private static Path resolveBuildFile(Path projectPath) {

--- a/build-inspectors/src/main/java/dev/modernjava/upgrade/build/GradleVersionCatalog.java
+++ b/build-inspectors/src/main/java/dev/modernjava/upgrade/build/GradleVersionCatalog.java
@@ -1,5 +1,7 @@
 package dev.modernjava.upgrade.build;
 
+import dev.modernjava.upgrade.core.InspectorDiagnostic;
+import dev.modernjava.upgrade.core.InspectorDiagnosticSeverity;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -14,23 +16,28 @@ import org.tomlj.TomlTable;
 final class GradleVersionCatalog {
 
     private static final GradleVersionCatalog EMPTY =
-            new GradleVersionCatalog(Map.of(), Map.of(), Map.of());
+            new GradleVersionCatalog(Map.of(), Map.of(), Map.of(), List.of());
+    private static final Path CATALOG_PATH = Path.of("gradle", "libs.versions.toml");
+    private static final String DIAGNOSTIC_SOURCE = "Gradle version catalog";
 
     private final Map<String, CatalogLibrary> libraries;
     private final Map<String, CatalogPlugin> plugins;
     private final Map<String, List<String>> bundles;
+    private final List<InspectorDiagnostic> diagnostics;
 
     private GradleVersionCatalog(
             Map<String, CatalogLibrary> libraries,
             Map<String, CatalogPlugin> plugins,
-            Map<String, List<String>> bundles) {
+            Map<String, List<String>> bundles,
+            List<InspectorDiagnostic> diagnostics) {
         this.libraries = libraries;
         this.plugins = plugins;
         this.bundles = bundles;
+        this.diagnostics = List.copyOf(diagnostics);
     }
 
     static GradleVersionCatalog read(Path projectRoot) {
-        var catalogFile = projectRoot.resolve("gradle").resolve("libs.versions.toml");
+        var catalogFile = projectRoot.resolve(CATALOG_PATH);
         if (!Files.isRegularFile(catalogFile)) {
             return EMPTY;
         }
@@ -39,17 +46,34 @@ final class GradleVersionCatalog {
         try {
             result = Toml.parse(Files.readString(catalogFile));
         } catch (IOException exception) {
-            return EMPTY;
+            return withDiagnostic("Could not read version catalog; catalog aliases were skipped.");
         }
         if (result.hasErrors()) {
-            return EMPTY;
+            return withDiagnostic("Could not parse version catalog; catalog aliases were skipped.");
         }
 
         var versions = collectVersions(result);
         return new GradleVersionCatalog(
                 collectLibraries(result),
                 collectPlugins(result, versions),
-                collectBundles(result));
+                collectBundles(result),
+                List.of());
+    }
+
+    List<InspectorDiagnostic> diagnostics() {
+        return diagnostics;
+    }
+
+    private static GradleVersionCatalog withDiagnostic(String message) {
+        return new GradleVersionCatalog(
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                List.of(new InspectorDiagnostic(
+                        DIAGNOSTIC_SOURCE,
+                        InspectorDiagnosticSeverity.WARNING,
+                        message,
+                        CATALOG_PATH)));
     }
 
     void addDependencies(String reference, Set<String> dependencies) {

--- a/build-inspectors/src/test/java/dev/modernjava/upgrade/build/GradleProjectInspectorTest.java
+++ b/build-inspectors/src/test/java/dev/modernjava/upgrade/build/GradleProjectInspectorTest.java
@@ -102,6 +102,14 @@ class GradleProjectInspectorTest {
         assertThat(metadata.springBootVersion()).isEqualTo("3.3.5");
         assertThat(metadata.dependencies()).containsExactly("org.springframework.boot:spring-boot-starter-web");
         assertThat(metadata.buildPlugins()).contains("java", "org.springframework.boot");
+        assertThat(metadata.diagnostics())
+                .singleElement()
+                .satisfies(diagnostic -> {
+                    assertThat(diagnostic.source()).isEqualTo("Gradle version catalog");
+                    assertThat(diagnostic.severity().name()).isEqualTo("WARNING");
+                    assertThat(diagnostic.message()).contains("Could not parse version catalog");
+                    assertThat(diagnostic.path()).isEqualTo(Path.of("gradle", "libs.versions.toml"));
+                });
     }
 
     @Test

--- a/cli/src/main/java/dev/modernjava/upgrade/cli/AnalyzeCommand.java
+++ b/cli/src/main/java/dev/modernjava/upgrade/cli/AnalyzeCommand.java
@@ -48,7 +48,8 @@ public final class AnalyzeCommand implements Callable<Integer> {
                     inspectedMetadata.dependencies(),
                     inspectedMetadata.buildPlugins(),
                     inspectedMetadata.compilerArgs(),
-                    sourcePatterns);
+                    sourcePatterns,
+                    inspectedMetadata.diagnostics());
             var result = new DefaultAnalyzer(metadata).analyze(request);
             var markdown = new MarkdownReportRenderer().render(request, result);
             writeReport(markdown);


### PR DESCRIPTION
## Summary

- Add an inspector diagnostics model with source, severity, message, and optional path.
- Carry diagnostics through `ProjectMetadata` and preserve them when the CLI combines build metadata with source patterns.
- Render diagnostics in a dedicated Markdown report section.
- Emit a Gradle version catalog warning when `gradle/libs.versions.toml` cannot be parsed while preserving visible build-file inspection.

## Validation

- RED: `mvn -pl analyzer-core,build-inspectors -am '-Dtest=MarkdownReportRendererTest,GradleProjectInspectorTest' '-Dsurefire.failIfNoSpecifiedTests=false' test '-Dmaven.compiler.release=22'` first failed because the diagnostics model did not exist, then failed because malformed catalog diagnostics were not emitted.
- `mvn -pl analyzer-core,build-inspectors -am '-Dtest=MarkdownReportRendererTest,GradleProjectInspectorTest' '-Dsurefire.failIfNoSpecifiedTests=false' test '-Dmaven.compiler.release=22'`
- `mvn clean test '-Dmaven.compiler.release=22'`
- `python -B scripts/check-local-markdown-links.py`
- `git diff --check`

Closes #25.